### PR TITLE
Add support for tuple destructuring in for loops and implement UNPACK_SEQUENCE opcode

### DIFF
--- a/docs/BYTECODE.md
+++ b/docs/BYTECODE.md
@@ -21,7 +21,7 @@ Key groups:
 **Argument**: Count of values to unpack (N)  
 **Stack Effect**: Replaces TOS with N values
 
-Pops a sequence (list, tuple, or set) from the top of the stack and pushes its elements onto the stack in reverse order (rightmost element pushed last). Validates that the sequence has exactly N elements, raising `ValueError` if the count doesn't match.
+Pops a sequence (list, tuple, or set) from the top of the stack and pushes its elements onto the stack in reverse order (rightmost element pushed first). Validates that the sequence has exactly N elements, raising `ValueError` if the count doesn't match.
 
 Example:
 

--- a/docs/BYTECODE.md
+++ b/docs/BYTECODE.md
@@ -11,8 +11,31 @@ Key groups:
 - Compare: `COMPARE_OP` with arg mapping (0..9) for `<, <=, ==, !=, >, >=, is, is not, in, not in`
 - Control flow: `JUMP_FORWARD`, `POP_JUMP_IF_TRUE`, `POP_JUMP_IF_FALSE`, `JUMP_IF_TRUE_OR_POP`, `JUMP_IF_FALSE_OR_POP`, `SETUP_LOOP`, `POP_BLOCK`, `BREAK_LOOP`, `CONTINUE_LOOP`, `RETURN_VALUE`
 - Iteration: `GET_ITER`, `FOR_ITER`
+- Unpacking: `UNPACK_SEQUENCE` - unpacks a sequence (list/tuple) into N values on the stack
 - Collections: `BUILD_LIST`, `BUILD_TUPLE`, `BUILD_SET`, `BUILD_MAP`, `BUILD_MAP_UNPACK`
 - Functions: `MAKE_FUNCTION`, `CALL_FUNCTION`
+
+## UNPACK_SEQUENCE
+
+**Opcode**: `UNPACK_SEQUENCE`  
+**Argument**: Count of values to unpack (N)  
+**Stack Effect**: Replaces TOS with N values
+
+Pops a sequence (list, tuple, or set) from the top of the stack and pushes its elements onto the stack in reverse order (rightmost element pushed last). Validates that the sequence has exactly N elements, raising `ValueError` if the count doesn't match.
+
+Example:
+
+```python
+for x, y in [(1, 2), (3, 4)]:
+    print(x + y)
+```
+
+Bytecode includes:
+
+- `FOR_ITER` → pushes tuple `(1, 2)` onto stack
+- `UNPACK_SEQUENCE 2` → pops tuple, pushes `2` then `1`
+- `STORE_NAME` (for y) → pops `1`, stores in `y`
+- `STORE_NAME` (for x) → pops `2`, stores in `x`
 
 Constants:
 

--- a/docs/BYTECODE.md
+++ b/docs/BYTECODE.md
@@ -34,8 +34,8 @@ Bytecode includes:
 
 - `FOR_ITER` → pushes tuple `(1, 2)` onto stack
 - `UNPACK_SEQUENCE 2` → pops tuple, pushes `2` then `1`
-- `STORE_NAME` (for y) → pops `1`, stores in `y`
 - `STORE_NAME` (for x) → pops `2`, stores in `x`
+- `STORE_NAME` (for y) → pops `1`, stores in `y`
 
 Constants:
 

--- a/docs/COMPILER.md
+++ b/docs/COMPILER.md
@@ -28,9 +28,13 @@ Compiles AST into a compact Python-like bytecode executed by the VM.
 
 - Expr → evaluate + `POP_TOP`
 - Assign / AugAssign → load/store targets; attribute/subscript targets supported
+  - Tuple assignment targets fully supported with recursive unpacking
 - If/elif/else → conditional with `POP_JUMP_IF_FALSE` and `JUMP_FORWARD` (patched)
 - While → `SETUP_LOOP` + test/jumps; supports `break`/`continue` and optional `else`
-- For → `GET_ITER` + `FOR_ITER` loop; stores to simple Name targets
+- For → `GET_ITER` + `FOR_ITER` loop; supports tuple destructuring via `UNPACK_SEQUENCE`
+  - Simple targets: `for x in items:`
+  - Tuple targets: `for x, y in items:` or `for (x, y) in items:`
+  - Nested tuples: `for (a, b), c in items:` recursively unpacks
 - Return → push value or `None` and `RETURN_VALUE`
 - FunctionDef → compiles nested CodeObject and creates a function via `MAKE_FUNCTION`, then `STORE_NAME`
 - Module → implicit final `return None`
@@ -43,5 +47,4 @@ Compiles AST into a compact Python-like bytecode executed by the VM.
 ## Known gaps
 
 - Chained comparisons not yet emitted (parser may build them)
-- For-loop assignment targets beyond simple Name are not yet compiled
 - Function defaults/kwargs in `MAKE_FUNCTION` are stubbed

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -3,7 +3,6 @@
 A practical subset is implemented; some features are deferred or partial:
 
 - Comparisons: identity (`is`) and membership (`in`) semantics are simplified compared to CPython
-- For-loop targets: only simple `Name` targets compiled (no tuple destructuring yet)
 - Function defs: default args/kwargs are stubbed; `MAKE_FUNCTION` ignores defaults
 - Exceptions: structured exception handling not implemented
 - f-strings: prefixes tokenized; full runtime interpolation/formatting still in progress

--- a/docs/PARSER.md
+++ b/docs/PARSER.md
@@ -18,11 +18,13 @@ Parses tokens into a Python-like AST. Split across small modules for maintainabi
 
 ## Statements supported
 
-- Assign: simple and multiple targets (Name, attribute, subscript; see compiler limitations)
+- Assign: simple and multiple targets (Name, attribute, subscript; tuple destructuring fully supported)
 - AugAssign: `+=, -=, *=, /=, //=, %=, **=, <<=, >>=, &=, ^=, |=, @=`
 - Expr statements: function calls, expressions
 - Control flow: `if`/`elif`/`else`
 - Loops: `while`, `for ... in ...` (+ optional `else:`)
+  - For-loop targets support tuple destructuring: `for x, y in items:` or `for (x, y) in items:`
+  - Nested tuple destructuring: `for (a, b), c in items:` works recursively
 - Function definitions: `def name(args): ...`
 
 ## Notes

--- a/docs/examples/control_flow.luau
+++ b/docs/examples/control_flow.luau
@@ -37,4 +37,23 @@ for n in range(3):
 
 for v in ["a", "b", "c"]:
     print("list:", v)
+
+# Iterate over list of tuples
+for x, y in [(1, 2), (3, 4), (5, 6)]:
+    print(f"x={x}, y={y}, sum={x + y}")
+
+# Parenthesized tuple targets work too
+for (a, b) in [(10, 20), (30, 40)]:
+    print(f"a={a}, b={b}, product={a * b}")
+
+# Triple tuple destructuring
+coordinates = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+for x, y, z in coordinates:
+    print(f"point: ({x}, {y}, {z})")
+
+# Nested tuple destructuring
+data = [((1, 2), 100), ((3, 4), 200)]
+for (a, b), value in data:
+    print(f"pair ({a}, {b}) has value {value}")
 ]])
+

--- a/src/PyLua/bytecode/opcodes.luau
+++ b/src/PyLua/bytecode/opcodes.luau
@@ -52,6 +52,8 @@ export type Opcode =
 	-- Iteration
 	| "GET_ITER"
 	| "FOR_ITER"
+	-- Unpacking
+	| "UNPACK_SEQUENCE"
 	-- Function calls
 	| "MAKE_FUNCTION"
 	| "CALL_FUNCTION"
@@ -135,6 +137,9 @@ local OPCODE_INFO: { [Opcode]: OpcodeInfo } = {
 	-- Iteration
 	GET_ITER = { name = "GET_ITER", arg = false, doc = "Get iterator from iterable" },
 	FOR_ITER = { name = "FOR_ITER", arg = true, doc = "Iterate over iterator or jump" },
+
+	-- Unpacking
+	UNPACK_SEQUENCE = { name = "UNPACK_SEQUENCE", arg = true, doc = "Unpack sequence into N values" },
 
 	-- Function calls
 	MAKE_FUNCTION = { name = "MAKE_FUNCTION", arg = true, doc = "Create function object" },

--- a/src/PyLua/compiler.luau
+++ b/src/PyLua/compiler.luau
@@ -333,6 +333,9 @@ local function compileAssignmentTarget(st: CompilerState, target: any)
 		compileName(st, target)
 	elseif target.type == "Tuple" then
 		-- For tuple targets, we need to unpack the value on TOS
+		-- Set context to Store for consistency
+		target.ctx = "Store"
+		
 		-- Emit UNPACK_SEQUENCE with the count of elements
 		local count = #target.elts
 		emit(st, "UNPACK_SEQUENCE", count, target.lineno)

--- a/src/PyLua/compiler.luau
+++ b/src/PyLua/compiler.luau
@@ -326,6 +326,39 @@ local function compileName(st: CompilerState, node: any)
 	end
 end
 
+-- Compile an assignment target (handles Name, Tuple, etc.)
+local function compileAssignmentTarget(st: CompilerState, target: any)
+	if target.type == "Name" then
+		target.ctx = "Store"
+		compileName(st, target)
+	elseif target.type == "Tuple" then
+		-- For tuple targets, we need to unpack the value on TOS
+		-- Emit UNPACK_SEQUENCE with the count of elements
+		local count = #target.elts
+		emit(st, "UNPACK_SEQUENCE", count, target.lineno)
+		
+		-- Now compile each element as a store target
+		-- UNPACK_SEQUENCE pushes values in reverse order, so we store them in forward order
+		for _, elt in ipairs(target.elts) do
+			compileAssignmentTarget(st, elt)
+		end
+	elseif target.type == "Attribute" then
+		-- For attribute assignment: obj.attr = value
+		-- TOS is value, compile the object
+		compileExpr(st, target.value)
+		local idx = addName(st, target.attr)
+		emit(st, "STORE_ATTR", idx, target.lineno)
+	elseif target.type == "Subscript" then
+		-- For subscript assignment: obj[key] = value
+		-- TOS is value, need obj and key
+		compileExpr(st, target.value)
+		compileExpr(st, target.slice)
+		emit(st, "STORE_SUBSCR", nil, target.lineno)
+	else
+		error("Unsupported assignment target type: " .. tostring(target.type))
+	end
+end
+
 local BINOP_TO_OPCODE: { [nodes.BinOpType]: Opcode } = {
 	Add = "BINARY_ADD",
 	Sub = "BINARY_SUBTRACT",
@@ -711,13 +744,9 @@ compileStmt = function(st: CompilerState, node: any)
 		-- 6. Setup loop for break/continue
 		enterLoop(st, loopStart, forIterJump)
 
-		-- 7. Store the iteration value in the target variable
-		if node.target.type == "Name" then
-			node.target.ctx = "Store"
-			compileName(st, node.target)
-		else
-			error("Complex assignment targets not supported yet", 2)
-		end
+		-- 7. Store the iteration value in the target variable(s)
+		-- Now supports tuple unpacking: for x, y in items: ...
+		compileAssignmentTarget(st, node.target)
 
 		-- 8. Compile loop body
 		for _, stmt in ipairs(node.body) do

--- a/src/PyLua/parser/statements.luau
+++ b/src/PyLua/parser/statements.luau
@@ -266,11 +266,13 @@ function statements.parseCompound(state: any): Stmt
 			}
 		end
 		
+		-- Mark target as Store context before consuming 'in'
+		target = assignmentTarget(target)
+		
 		state:consume("IN", "Expected 'in' after for target")
 		local iter = expressions.parse(state)
 		state:consume("COLON", "Expected ':' after for clause")
 		local body = parseSuiteAfterColon(state)
-		target = assignmentTarget(target)
 		return {
 			type = "For",
 			target = target,

--- a/src/PyLua/parser/statements.luau
+++ b/src/PyLua/parser/statements.luau
@@ -7,9 +7,57 @@ export type Stmt = nodes.Stmt
 
 local statements = {}
 
+-- Helper to recursively parse assignment targets (including nested tuples)
+local function parseForTarget(state: any): Expr
+	if state.current and state.current.type == "LPAR" then
+		-- Parenthesized tuple
+		local lparToken = state.current
+		state:advance() -- consume LPAR
+		
+		local elements: { Expr } = {}
+		if state.current and state.current.type ~= "RPAR" then
+			-- Parse first element (recursively handles nested tuples)
+			table.insert(elements, parseForTarget(state))
+			
+			-- Parse remaining elements
+			while state.current and state.current.type == "COMMA" do
+				state:advance() -- consume COMMA
+				if state.current and state.current.type == "RPAR" then
+					break -- trailing comma
+				end
+				table.insert(elements, parseForTarget(state))
+			end
+		end
+		
+		state:consume("RPAR", "Expected ')' to close tuple")
+		
+		-- Create tuple node
+		return {
+			type = "Tuple",
+			elts = elements,
+			ctx = "Load",
+			lineno = lparToken.line,
+			col_offset = lparToken.column,
+		}
+	else
+		-- Simple name or name with subscript/attribute
+		local targetOpt = expressions.parsePrimaryForTarget(state)
+		if not targetOpt then
+			state:raise("Invalid for target element")
+		end
+		return targetOpt :: Expr
+	end
+end
+
 local function assignmentTarget(expr: Expr): Expr
 	if expr.type == "Name" or expr.type == "Attribute" or expr.type == "Subscript" then
 		(expr :: any).ctx = "Store"
+	elseif expr.type == "Tuple" then
+		-- Recursively mark tuple elements as store targets
+		(expr :: any).ctx = "Store"
+		for _, elt in ipairs((expr :: any).elts) do
+			assignmentTarget(elt)
+		end
 	end
 	return expr
 end
@@ -190,11 +238,34 @@ function statements.parseCompound(state: any): Stmt
 	end
 	if current.type == "FOR" then
 		state:advance()
-		local targetOpt = expressions.parsePrimaryForTarget(state)
-		if not targetOpt then
-			state:raise("Invalid for target")
+		-- Parse the target - can be a Name or a Tuple for destructuring
+		local target: Expr
+		
+		-- Parse the first part of the target
+		target = parseForTarget(state)
+		
+		-- Check if there's a comma, making it an implicit tuple
+		if state.current and state.current.type == "COMMA" then
+			-- Implicit tuple without parens: for x, y in items: or for (a, b), c in items:
+			local elements = { target }
+			while state.current and state.current.type == "COMMA" do
+				state:advance()
+				-- Check if we hit 'in' (trailing comma case)
+				if state.current and state.current.type == "IN" then
+					break
+				end
+				table.insert(elements, parseForTarget(state))
+			end
+			-- Create tuple node
+			target = {
+				type = "Tuple",
+				elts = elements,
+				ctx = "Load",
+				lineno = elements[1].lineno,
+				col_offset = elements[1].col_offset,
+			}
 		end
-		local target = targetOpt :: Expr
+		
 		state:consume("IN", "Expected 'in' after for target")
 		local iter = expressions.parse(state)
 		state:consume("COLON", "Expected ':' after for clause")

--- a/src/PyLua/vm/interpreter.luau
+++ b/src/PyLua/vm/interpreter.luau
@@ -563,6 +563,50 @@ local function executeInstruction(
 			frame.skip_advance = true
 		end
 
+	-- Unpacking
+	elseif opcode == "UNPACK_SEQUENCE" then
+		assert(arg ~= nil, "UNPACK_SEQUENCE requires argument")
+		local sequence = Frame.pop(frame)
+		
+		-- Get the underlying array from PyObject sequences
+		local values: { any }
+		if type(sequence) == "table" then
+			local obj = sequence :: any
+			if obj.__type == "list" or obj.__type == "tuple" then
+				values = obj.__value
+			elseif obj.__type == "set" then
+				-- Sets are unordered, but we need to extract values
+				local arr = {}
+				for _, entry in pairs(obj.__value) do
+					arr[#arr + 1] = entry.value
+				end
+				values = arr
+			else
+				error("ValueError: cannot unpack non-sequence", 2)
+			end
+		else
+			error("ValueError: cannot unpack non-sequence", 2)
+		end
+		
+		-- Check that we have the right number of values
+		if #values ~= arg then
+			error(
+				string.format(
+					"ValueError: too %s values to unpack (expected %d, got %d)",
+					if #values < arg then "few" else "many",
+					arg,
+					#values
+				),
+				2
+			)
+		end
+		
+		-- Push values onto stack in reverse order (rightmost first)
+		-- So they can be popped in forward order for assignment
+		for i = #values, 1, -1 do
+			Frame.push(frame, values[i])
+		end
+
 	-- Collections
 	elseif opcode == "BUILD_LIST" then
 		assert(arg ~= nil, "BUILD_LIST requires argument")

--- a/tests/suites/test_control_flow.luau
+++ b/tests/suites/test_control_flow.luau
@@ -357,6 +357,60 @@ for i in [1, 2]:
 				TestFramework.assertEqual(globals.result, 86, "Continue should only skip inner iteration")
 			end,
 		},
+
+		{
+			name = "For Loop - Tuple Destructuring (Parenthesized)",
+			test = function()
+				local globals = executeCode([[
+result = []
+for (x, y) in [(1, 2), (3, 4), (5, 6)]:
+    result.append(x + y)
+]])
+				TestFramework.assertEqual(globals.result.__value[1].__value, 3, "First tuple should unpack to 1+2=3")
+				TestFramework.assertEqual(globals.result.__value[2].__value, 7, "Second tuple should unpack to 3+4=7")
+				TestFramework.assertEqual(globals.result.__value[3].__value, 11, "Third tuple should unpack to 5+6=11")
+			end,
+		},
+
+		{
+			name = "For Loop - Tuple Destructuring (Implicit)",
+			test = function()
+				local globals = executeCode([[
+result = []
+for x, y in [(1, 2), (3, 4)]:
+    result.append(x * y)
+]])
+				TestFramework.assertEqual(globals.result.__value[1].__value, 2, "First tuple should unpack to 1*2=2")
+				TestFramework.assertEqual(globals.result.__value[2].__value, 12, "Second tuple should unpack to 3*4=12")
+			end,
+		},
+
+		{
+			name = "For Loop - Triple Tuple Destructuring",
+			test = function()
+				local globals = executeCode([[
+result = 0
+for x, y, z in [(1, 2, 3), (4, 5, 6)]:
+    result = result + x + y + z
+]])
+				-- Expected: (1+2+3) + (4+5+6) = 6 + 15 = 21
+				TestFramework.assertEqual(globals.result, 21, "Triple tuple destructuring should work")
+			end,
+		},
+
+		{
+			name = "For Loop - Nested Tuple Destructuring",
+			test = function()
+				local globals = executeCode([[
+result = []
+for (a, b), c in [((1, 2), 3), ((4, 5), 6)]:
+    result.append(a + b + c)
+]])
+				-- Expected: (1+2+3) = 6, (4+5+6) = 15
+				TestFramework.assertEqual(globals.result.__value[1].__value, 6, "First nested tuple should unpack correctly")
+				TestFramework.assertEqual(globals.result.__value[2].__value, 15, "Second nested tuple should unpack correctly")
+			end,
+		},
 	},
 }
 


### PR DESCRIPTION
Add support for tuple destructuring in for loops and implement UNPACK_SEQUENCE opcode

Updated documentation to reflect changes in bytecode and compiler behavior and added tests for various tuple destructuring scenarios in for loops.